### PR TITLE
Implement LSP proxy diagnostic watcher

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import pino from 'pino';
 import { createFileWatcher } from '../core/file-watcher';
+import { createLspWatcher } from '../core/lsp-watcher';
 
 const program = new Command();
 program
@@ -15,9 +16,17 @@ program
     logger.info('Starting file watcher...');
 
     const watcher = createFileWatcher({ logger });
+    const lspWatcher = createLspWatcher({ logger });
 
     watcher.on('hotState', () => {
       logger.info('hotState event received');
+    });
+
+    lspWatcher.on('lsphot', () => {
+      logger.info('lsphot event received');
+    });
+    lspWatcher.on('lspready', () => {
+      logger.info('lspready event received');
     });
   });
 

--- a/core/lsp-watcher.ts
+++ b/core/lsp-watcher.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import pino, { Logger } from 'pino';
+
+export interface LspWatcherOptions {
+  cwd?: string;
+  logger?: Logger;
+  tsserverPath?: string;
+}
+
+export function createLspWatcher(options: LspWatcherOptions = {}): EventEmitter {
+  const {
+    cwd = process.cwd(),
+    logger = pino({ name: 'uado:lsp-watcher' }),
+    tsserverPath = 'tsserver'
+  } = options;
+
+  const emitter = new EventEmitter();
+
+  const child = spawn(tsserverPath, ['--logVerbosity', 'terse'], {
+    cwd,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data: string | Buffer) => {
+    const text = data.toString();
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      logger.debug({ line }, 'tsserver stdout');
+      if (/Starting updateGraphWorker/.test(line)) {
+        logger.debug('tsserver hot');
+        emitter.emit('lsphot');
+      }
+      if (/Finishing updateGraphWorker/.test(line)) {
+        logger.debug('tsserver ready');
+        emitter.emit('lspready');
+      }
+    }
+  });
+
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (data: string | Buffer) => {
+    const text = data.toString();
+    logger.error({ text }, 'tsserver stderr');
+  });
+
+  child.on('error', (err) => {
+    logger.error({ err }, 'tsserver spawn error');
+  });
+
+  emitter.on('close', () => {
+    child.kill();
+  });
+
+  return emitter;
+}


### PR DESCRIPTION
## Summary
- create LSP watcher to spawn `tsserver` and emit `lsphot`/`lspready` events
- integrate LSP watcher with `uado watch`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e23e59204832ca732607eebda1af6