### PR TITLE
feat(cli): add prompt playground command

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,6 +3,7 @@ import pino from 'pino';
 import { createFileWatcher } from '../core/file-watcher';
 import { createLspWatcher } from '../core/lsp-watcher';
 import { registerDashboardCommand } from './dashboard';
+import { registerPromptCommand } from './prompt';
 
 const program = new Command();
 program
@@ -32,5 +33,6 @@ program
   });
 
 registerDashboardCommand(program);
+registerPromptCommand(program);
 
 program.parse(process.argv);

--- a/cli/prompt.ts
+++ b/cli/prompt.ts
@@ -1,0 +1,47 @@
+import { Command } from 'commander';
+import pino from 'pino';
+import { createCooldownEngine } from '../core/cooldown-engine';
+import { createOrchestrator } from '../core/orchestrator';
+
+export function registerPromptCommand(program: Command): void {
+  program
+    .command('prompt <text>')
+    .description('Send a test prompt through the orchestrator')
+    .action(async (text: string) => {
+      const logger = pino({ name: 'uado' });
+      const cooldown = createCooldownEngine({ logger });
+      const orchestrator = createOrchestrator({ cooldownEmitter: cooldown, logger });
+
+      const fakeCallAI = (input: string): Promise<string> =>
+        new Promise((res) => setTimeout(() => res(`Response: ${input}`), 1000));
+
+      let queued = false;
+      cooldown.on('cooldown:active', () => {
+        queued = true;
+        console.log('🔥 Cooldown active, queued prompt');
+      });
+      cooldown.on('cooldown:ended', () => {
+        if (queued) {
+          console.log('✅ Prompt accepted');
+          queued = false;
+        }
+      });
+
+      const waitLog = setTimeout(() => {
+        if (queued) {
+          console.log('🕒 Waiting...');
+        }
+      }, 200);
+
+      try {
+        const result = await orchestrator.wrapPrompt(() => fakeCallAI(text));
+        clearTimeout(waitLog);
+        if (!queued) {
+          console.log('✅ Prompt accepted');
+        }
+        console.log(result);
+      } finally {
+        orchestrator.close();
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- add `registerPromptCommand` in `cli/prompt.ts`
- register the command in the CLI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ce86c00832c90573f2d88341c9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI command: `prompt <text>`, allowing users to send test prompts and receive simulated AI responses with status updates and cooldown management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->