### PR TITLE
Add build setup for global uado binary

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import './cli/index';
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Universal AI Development Orchestrator (UADO) A CLI-based orchestration layer that synchronizes AI coding agents (GPT, Claude, Gemini) with real-time compiler and linter readiness. Prevents recursive fix loops and phantom errors by intelligently gating prompt timing using file watchers, diagnostic signals, and cooldown prediction.",
   "main": "index.js",
   "bin": {
-    "uado": "cli/index.js"
+    "uado": "./dist/index.js"
   },
   "scripts": {
+    "build": "tsc --outDir dist --rootDir . && chmod +x dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -25,6 +26,7 @@
     "@types/node": "^24.0.4",
     "memfs": "^4.17.2",
     "mock-fs": "^5.5.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "typescript": "^5.4.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -59,7 +59,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
## Summary
- add `bin` entry pointing to `dist/index.js`
- use TypeScript compiler to emit compiled files
- new `index.ts` with node shebang for CLI
- configure `outDir` and `rootDir` in tsconfig
- ensure executable permission on the compiled binary

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e33ac5244832ca98d4c1c917fe7ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new executable script for direct command-line usage.

* **Chores**
  * Updated the CLI executable path and build process in the configuration files.
  * Added TypeScript as a development dependency.
  * Adjusted TypeScript build settings to output compiled files to a dedicated directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->