### PR TITLE
Add SECURITY.md and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ await orchestrator.wrapPrompt(() => yourFunc());
 - **Link locally**: `npm link` (after building)
 - **Run in dev mode**: `node dist/index.js` or use the linked `uado` command
 
+
+## 🔐 Security & Privacy
+
+UADO is fully local-first. It does **not** send prompts, logs, or metadata to any external server.  
+All orchestration happens on your machine using local file watchers and diagnostic signals.  
+See [`SECURITY.md`](./SECURITY.md) for more details.
+
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Manifest
+
+UADO embraces a **local-first philosophy**. Everything it does happens on your machine so you remain in complete control.
+
+## ❌ UADO never does
+- Telemetry collection
+- API calls
+- Prompt uploads
+- Shell command execution
+
+## ✅ UADO does
+- Watch your files locally via [chokidar](https://github.com/paulmillr/chokidar)
+- Spawn `tsserver` for LSP signals
+- Buffer AI prompts in memory only
+- Log locally to your console
+
+## Auditing the CLI
+Review this repository or run the CLI while monitoring your network traffic. You should observe no outbound requests. Verbose logging can help trace every action.
+
+For any questions or security concerns, reach out to the maintainer at <security@example.com>.
+

--- a/cli/prompt.ts
+++ b/cli/prompt.ts
@@ -22,6 +22,12 @@ export function registerPromptCommand(program: Command): void {
       const fakeCallAI = (input: string): Promise<string> =>
         new Promise((res) => setTimeout(() => res(`Response: ${input}`), 1000));
 
+      // TODO: support a --dry-run flag
+      // if (dryRun) {
+      //   logger.info('Would execute prompt, but dry run is enabled.');
+      //   return;
+      // }
+
       let queued = false;
       cooldown.on('cooldown:active', () => {
         queued = true;


### PR DESCRIPTION
## Summary
- document local-first security philosophy in new SECURITY.md
- call out privacy guarantees in README
- stub `--dry-run` placeholder in `prompt` command

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e38af3b58832ca97a6a8f0e341bbf