### PR TITLE
Add manual CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,21 @@ uado dashboard
 
 ### Configuration
 
-Create a `.uadorc.json` in your project root to tweak cooldown behavior:
+Create a `.uadorc.json` in your project root to tweak cooldown behavior and set execution mode:
 
 ```json
 {
   "cooldownDurationMs": 90000,
   "stabilityWindowMs": 5000,
-  "logLevel": "info"
+  "logLevel": "info",
+  "mode": "manual"
 }
 ```
 
 - `cooldownDurationMs` – maximum time to stay in cooldown after a file change
 - `stabilityWindowMs` – how long to wait for file stability after the LSP signals readiness
 - `logLevel` – `info`, `debug`, or `silent`
+- `mode` – `manual` for copy/paste mode (used by default if no config file is found)
 
 ### In your own code
 

--- a/core/config-loader.ts
+++ b/core/config-loader.ts
@@ -6,12 +6,14 @@ export interface UadoConfig {
   cooldownDurationMs: number;
   stabilityWindowMs: number;
   logLevel: 'info' | 'debug' | 'silent';
+  mode: 'openai' | 'claude' | 'manual';
 }
 
 export const DEFAULT_CONFIG: UadoConfig = {
   cooldownDurationMs: 90_000,
   stabilityWindowMs: 5_000,
-  logLevel: 'info'
+  logLevel: 'info',
+  mode: 'openai'
 };
 
 export function loadConfig(configPath?: string, logger: Logger = pino({ name: 'uado:config-loader' })): UadoConfig {
@@ -24,10 +26,11 @@ export function loadConfig(configPath?: string, logger: Logger = pino({ name: 'u
     return merged;
   } catch (err: any) {
     if (err.code === 'ENOENT') {
-      logger.info({ path: resolved }, 'config file not found, using defaults');
+      logger.warn({ path: resolved }, 'config file not found, defaulting to manual mode');
+      return { ...DEFAULT_CONFIG, mode: 'manual' };
     } else {
       logger.error({ err, path: resolved }, 'failed to load config, using defaults');
+      return { ...DEFAULT_CONFIG };
     }
-    return { ...DEFAULT_CONFIG };
   }
 }


### PR DESCRIPTION
## Summary
- support new `mode` field in `.uadorc.json`
- fall back to manual mode when config file is missing
- print prompts in a copyable box and collect manual responses
- document configuration updates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e4c0c3cc8832ca3a59a04bf2f24fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "manual" mode that allows users to manually input AI responses when prompted, instead of using automatic AI generation.
  * Updated configuration options to support selecting between "openai", "claude", or "manual" modes.

* **Documentation**
  * Enhanced the README with details and examples for the new "mode" configuration option, including usage instructions for manual mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->