### PR TITLE
Add history command

### DIFF
--- a/cli/history.ts
+++ b/cli/history.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import { PasteLogEntry } from './logPaste';
+
+let chalk: {
+  cyan: (s: string) => string;
+  gray: (s: string) => string;
+  dim: (s: string) => string;
+  yellow: (s: string) => string;
+};
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  chalk = require('chalk');
+} catch {
+  chalk = {
+    cyan: (s: string) => s,
+    gray: (s: string) => s,
+    dim: (s: string) => s,
+    yellow: (s: string) => s
+  };
+}
+
+export function runHistoryCommand(): void {
+  const logPath = path.join(process.cwd(), '.uado', 'paste.log.json');
+
+  if (!fs.existsSync(logPath)) {
+    console.log('No paste history found yet.');
+    console.log('Try running `uado prompt` or `uado paste` first!');
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+  } catch (err: any) {
+    console.log('Failed to read paste history:', err.message);
+    return;
+  }
+
+  if (!Array.isArray(data)) {
+    console.log('Paste log is not in the expected format.');
+    return;
+  }
+
+  const entries = (data as PasteLogEntry[]).slice();
+  entries.sort((a, b) =>
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  if (entries.length === 0) {
+    console.log('No paste history found yet.');
+    console.log('Try running `uado prompt` or `uado paste` first!');
+    return;
+  }
+
+  for (const entry of entries) {
+    const preview = entry.prompt.replace(/\s+/g, ' ').slice(0, 100);
+    console.log(`📄 ${chalk.cyan(entry.file)}`);
+    console.log(`  🕓 ${chalk.dim(entry.timestamp)}  🔠 ${entry.bytesWritten} bytes`);
+    console.log(`  🧠 ${chalk.gray(preview)}`);
+    if (typeof entry.queueIndex === 'number') {
+      console.log(`  🧾 ${chalk.yellow(String(entry.queueIndex))}`);
+      console.log(
+        chalk.dim(`  To replay this paste, run: uado replay ${entry.queueIndex}`)
+      );
+    }
+    console.log('');
+  }
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5,6 +5,7 @@ import { createLspWatcher } from '../core/lsp-watcher';
 import { loadConfig } from '../core/config-loader';
 import { registerDashboardCommand } from './dashboard';
 import { registerPromptCommand } from './prompt';
+import { runHistoryCommand } from './history';
 
 const program = new Command();
 program
@@ -38,5 +39,9 @@ program
 
 registerDashboardCommand(program);
 registerPromptCommand(program);
+program
+  .command('history')
+  .description('Show paste history')
+  .action(runHistoryCommand);
 
 program.parse(process.argv);


### PR DESCRIPTION
## Summary
- add `runHistoryCommand` for displaying paste logs
- wire up the `history` command in the CLI

## Testing
- `npm run build`
- `node dist/index.js history`

------
https://chatgpt.com/codex/tasks/task_e_685e72192680832cb5f82fe49bf180ec