### PR TITLE
Add replay command

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@ import { loadConfig } from '../core/config-loader';
 import { registerDashboardCommand } from './dashboard';
 import { registerPromptCommand } from './prompt';
 import { runHistoryCommand } from './history';
+import { runReplayCommand } from './replay';
 import { printInfo } from './ui';
 
 const program = new Command();
@@ -46,6 +47,10 @@ program
   .command('history')
   .description('Show paste history')
   .action(runHistoryCommand);
+program
+  .command('replay <index>')
+  .description('Replay queued paste files')
+  .action(runReplayCommand);
 maybeShowWelcome();
 program.parse(process.argv);
 


### PR DESCRIPTION
## Summary
- implement `uado replay <index>` to restore queued files
- register the new command with the CLI router

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e7b625a78832c9eecdbb73d794e35