### PR TITLE
Add SHA-256 hashes to paste logs

### DIFF
--- a/cli/logPaste.ts
+++ b/cli/logPaste.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { printError } from './ui';
+import { computeHash } from '../utils/hash';
 
 export interface PasteLogEntry {
   timestamp: string;
@@ -10,6 +11,7 @@ export interface PasteLogEntry {
   queueIndex: number;
   wasOverwrite: boolean;
   error?: string;
+  hash?: string;
 }
 
 export function logPaste(entry: PasteLogEntry): void {
@@ -35,6 +37,13 @@ export function logPaste(entry: PasteLogEntry): void {
     log = [];
   }
 
+  try {
+    const hash = computeHash(entry);
+    if (hash) entry.hash = hash;
+  } catch {
+    // ignore hashing errors
+  }
+
   log.push(entry);
 
   try {
@@ -49,6 +58,7 @@ export interface PasteQueueEntry {
   prompt: string;
   timestamp: string;
   files: PasteLogEntry[];
+  hash?: string;
 }
 
 export function logQueueEntry(entry: PasteQueueEntry): void {
@@ -81,6 +91,13 @@ export function logQueueEntry(entry: PasteQueueEntry): void {
       : 1;
 
   entry.queueIndex = nextIndex;
+
+  try {
+    const hash = computeHash(entry);
+    if (hash) entry.hash = hash;
+  } catch {
+    // ignore hashing errors
+  }
   log.push(entry);
 
   try {

--- a/utils/hash.ts
+++ b/utils/hash.ts
@@ -1,0 +1,20 @@
+import crypto from 'crypto';
+
+function canonicalStringify(value: any): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map((v) => canonicalStringify(v)).join(',') + ']';
+  }
+  const keys = Object.keys(value).sort();
+  const entries = keys.map((k) =>
+    JSON.stringify(k) + ':' + canonicalStringify((value as any)[k])
+  );
+  return '{' + entries.join(',') + '}';
+}
+
+export function computeHash(data: object): string {
+  const str = canonicalStringify(data);
+  return crypto.createHash('sha256').update(str).digest('hex');
+}


### PR DESCRIPTION
## Summary
- add computeHash utility for canonical SHA-256 hashing
- store optional `hash` field on `PasteLogEntry` and `PasteQueueEntry`
- compute hashes when writing paste and queue logs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e7b6f2738832ca1ff03cd41fe8692