### PR TITLE
Add CLI test framework

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@ import { loadConfig } from '../core/config-loader';
 import { registerDashboardCommand } from './dashboard';
 import { registerPromptCommand } from './prompt';
 import { runHistoryCommand } from './history';
+import { registerTestCommand } from './test';
 import { printInfo } from './ui';
 
 const program = new Command();
@@ -42,6 +43,7 @@ program
 
 registerDashboardCommand(program);
 registerPromptCommand(program);
+registerTestCommand(program);
 program
   .command('history')
   .description('Show paste history')

--- a/cli/test.ts
+++ b/cli/test.ts
@@ -1,0 +1,52 @@
+import { Command } from 'commander';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { logPaste, logQueueEntry, PasteLogEntry, PasteQueueEntry } from './logPaste';
+import { printInfo, printSuccess } from './ui';
+
+export function registerTestCommand(program: Command): void {
+  const test = program.command('test').description('Testing utilities');
+
+  test
+    .command('run')
+    .description('Run CLI tests')
+    .action(() => {
+      const testFile = path.join(__dirname, '..', 'test', 'cli.test.js');
+      const result = spawnSync('node', [testFile], { stdio: 'inherit' });
+      process.exitCode = result.status === null ? 1 : result.status;
+    });
+
+  test
+    .command('mock-paste')
+    .description('Generate fake log entries for manual inspection')
+    .action(runMockPaste);
+}
+
+function runMockPaste(): void {
+  const timestamp = '2024-01-01T00:00:00.000Z';
+  const files = ['fileA.ts', 'fileB.ts', 'fileC.ts'];
+  const entries: PasteLogEntry[] = [];
+
+  for (const file of files) {
+    const entry: PasteLogEntry = {
+      timestamp,
+      file,
+      bytesWritten: 10,
+      prompt: 'Mock prompt',
+      queueIndex: 1,
+      wasOverwrite: false
+    };
+    logPaste(entry);
+    entries.push(entry);
+    printInfo(`📝 Mock paste logged: ${file}`);
+  }
+
+  const qEntry: PasteQueueEntry = {
+    queueIndex: 1,
+    prompt: 'Mock prompt',
+    timestamp,
+    files: entries
+  };
+  logQueueEntry(qEntry);
+  printSuccess('Mock queue entry logged.');
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc --outDir dist --rootDir . && chmod +x dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run build && node dist/test/cli.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/__snapshots__/history.txt
+++ b/test/__snapshots__/history.txt
@@ -1,0 +1,18 @@
+📄 fileA.ts
+  🕓 2024-01-01T00:00:00.000Z  🔠 10 bytes
+  🧠 Mock prompt
+  🧾 1
+  To replay this paste, run: uado replay 1
+
+📄 fileB.ts
+  🕓 2024-01-01T00:00:00.000Z  🔠 10 bytes
+  🧠 Mock prompt
+  🧾 1
+  To replay this paste, run: uado replay 1
+
+📄 fileC.ts
+  🕓 2024-01-01T00:00:00.000Z  🔠 10 bytes
+  🧠 Mock prompt
+  🧾 1
+  To replay this paste, run: uado replay 1
+

--- a/test/__snapshots__/paste.log.json
+++ b/test/__snapshots__/paste.log.json
@@ -1,0 +1,26 @@
+[
+  {
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "file": "fileA.ts",
+    "bytesWritten": 10,
+    "prompt": "Mock prompt",
+    "queueIndex": 1,
+    "wasOverwrite": false
+  },
+  {
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "file": "fileB.ts",
+    "bytesWritten": 10,
+    "prompt": "Mock prompt",
+    "queueIndex": 1,
+    "wasOverwrite": false
+  },
+  {
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "file": "fileC.ts",
+    "bytesWritten": 10,
+    "prompt": "Mock prompt",
+    "queueIndex": 1,
+    "wasOverwrite": false
+  }
+]

--- a/test/__snapshots__/queue.log.json
+++ b/test/__snapshots__/queue.log.json
@@ -1,0 +1,33 @@
+[
+  {
+    "queueIndex": 1,
+    "prompt": "Mock prompt",
+    "timestamp": "2024-01-01T00:00:00.000Z",
+    "files": [
+      {
+        "timestamp": "2024-01-01T00:00:00.000Z",
+        "file": "fileA.ts",
+        "bytesWritten": 10,
+        "prompt": "Mock prompt",
+        "queueIndex": 1,
+        "wasOverwrite": false
+      },
+      {
+        "timestamp": "2024-01-01T00:00:00.000Z",
+        "file": "fileB.ts",
+        "bytesWritten": 10,
+        "prompt": "Mock prompt",
+        "queueIndex": 1,
+        "wasOverwrite": false
+      },
+      {
+        "timestamp": "2024-01-01T00:00:00.000Z",
+        "file": "fileC.ts",
+        "bytesWritten": 10,
+        "prompt": "Mock prompt",
+        "queueIndex": 1,
+        "wasOverwrite": false
+      }
+    ]
+  }
+]

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { compareSnapshot, readJSON } from './utils';
+
+interface TestResult { name: string; passed: boolean; message?: string; }
+
+const cliPath = path.resolve(__dirname, '..', 'index.js');
+
+function runCmd(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const res = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf8' });
+  return { stdout: res.stdout, stderr: res.stderr, status: res.status };
+}
+
+function testMockPaste(tmpDir: string): TestResult {
+  runCmd(['test', 'mock-paste'], tmpDir);
+  const pastePath = path.join(tmpDir, '.uado', 'paste.log.json');
+  const queuePath = path.join(tmpDir, '.uado', 'queue.log.json');
+  const actualPaste = readJSON(pastePath);
+  const actualQueue = readJSON(queuePath);
+  const snapDir = path.join(__dirname, '../../test/__snapshots__');
+  const ok1 = compareSnapshot(actualPaste, path.join(snapDir, 'paste.log.json'));
+  const ok2 = compareSnapshot(actualQueue, path.join(snapDir, 'queue.log.json'));
+  return { name: 'test-mock-paste', passed: ok1 && ok2, message: !(ok1 && ok2) ? 'snapshot mismatch' : undefined };
+}
+
+function testHistoryOutput(tmpDir: string): TestResult {
+  const res = runCmd(['history'], tmpDir);
+  const snapDir = path.join(__dirname, '../../test/__snapshots__');
+  const expected = fs.readFileSync(path.join(snapDir, 'history.txt'), 'utf8');
+  const passed = res.stdout.trim() === expected.trim();
+  return { name: 'test-history', passed, message: passed ? undefined : 'output mismatch' };
+}
+
+function main(): void {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uado-test-'));
+  const results = [testMockPaste(tmpDir), testHistoryOutput(tmpDir)];
+
+  for (const r of results) {
+    if (r.passed) {
+      console.log(`\u2705 ${r.name}: PASS`);
+    } else {
+      console.log(`\u274c ${r.name}: FAIL${r.message ? ' (' + r.message + ')' : ''}`);
+    }
+  }
+
+  const failed = results.some((r) => !r.passed);
+  if (failed) process.exit(1);
+}
+
+main();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+
+export function compareSnapshot(actual: unknown, expectedPath: string): boolean {
+  if (!fs.existsSync(expectedPath)) {
+    return false;
+  }
+  const expectedRaw = fs.readFileSync(expectedPath, 'utf8');
+  const expected = JSON.parse(expectedRaw);
+  return JSON.stringify(actual, null, 2) === JSON.stringify(expected, null, 2);
+}
+
+export function readJSON(file: string): any {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}


### PR DESCRIPTION
## Summary
- add `uado test` command with `run` and `mock-paste` subcommands
- implement snapshot-based CLI tests
- create helper utilities for tests
- add npm test script to run compiled tests

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_685e7b9467b0832c807b09af6cdd4cb2