### PR TITLE
Improve CLI UX and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,46 @@
 # UADO
 
-**Universal AI Development Orchestrator** – a CLI tool that syncs AI coding agents with your editor's compile and lint cycle, preventing recursive prompt loops.
+**Universal AI Development Orchestrator** – a CLI tool that synchronizes AI coding agents with your editor's compile and lint cycle.
+
+## Features
+- Prompt handling with cooldown prediction
+- Paste and queue logging to `.uado/`
+- `history` command for browsing past prompts
+- `replay` command for restoring queued files
+- Built‑in test framework
+- `--simulate-queue` option for prompt testing
+- Styled CLI output with optional emoji icons
 
 ## Installation
-
 ```bash
 npm install -g uado
 ```
 
-## Usage
-
-### CLI
-
-Run a prompt through the orchestrator or open the live dashboard:
-
+## CLI Usage
 ```bash
+# Send a prompt
 uado prompt "your prompt"
+
+# Generate fake log entries
+uado prompt --simulate-queue "test"
+
+# View live system dashboard
 uado dashboard
+
+# Show paste history
+uado history
+
+# Replay a queue entry
+uado replay <index>
+
+# Run regression tests
+uado test run
 ```
 
-### Configuration
+Add `--no-emoji` to disable icons if your terminal does not display them correctly.
 
+## Configuration
 Create a `.uadorc.json` in your project root to tweak cooldown behavior and set execution mode:
-
 ```json
 {
   "cooldownDurationMs": 90000,
@@ -31,16 +49,23 @@ Create a `.uadorc.json` in your project root to tweak cooldown behavior and set 
   "mode": "manual"
 }
 ```
-
 - `cooldownDurationMs` – maximum time to stay in cooldown after a file change
 - `stabilityWindowMs` – how long to wait for file stability after the LSP signals readiness
 - `logLevel` – `info`, `debug`, or `silent`
 - `mode` – `manual` for copy/paste mode (used by default if no config file is found)
 
+## Project Structure
+```
+cli/       # command implementations
+core/      # cooldown engine and watchers
+utils/     # helper utilities
+types/     # ambient TypeScript types
+```
+
+More details can be found in [detailed_instructions.md](./detailed_instructions.md).
+
 ### In your own code
-
 Use the orchestrator programmatically:
-
 ```ts
 import { createCooldownEngine } from 'uado/dist/core/cooldown-engine';
 import { createOrchestrator } from 'uado/dist/core/orchestrator';
@@ -52,16 +77,11 @@ await orchestrator.wrapPrompt(() => yourFunc());
 ```
 
 ## Contributing
-
 - **Build**: `npm run build`
 - **Link locally**: `npm link` (after building)
 - **Run in dev mode**: `node dist/index.js` or use the linked `uado` command
 
-
 ## 🔐 Security & Privacy
-
-UADO is fully local-first. It does **not** send prompts, logs, or metadata to any external server.  
-All orchestration happens on your machine using local file watchers and diagnostic signals.  
+UADO is fully local-first. It does **not** send prompts, logs, or metadata to any external server.
+All orchestration happens on your machine using local file watchers and diagnostic signals.
 See [`SECURITY.md`](./SECURITY.md) for more details.
-
-

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -11,13 +11,14 @@ import { runHistoryCommand } from './history';
 import { registerTestCommand } from './test';
 import { runReplayCommand } from './replay';
 
-import { printInfo } from './ui';
+import { printInfo, setUseEmoji } from './ui';
 
 const program = new Command();
 program
   .name('uado')
   .description('Universal AI Development Orchestrator')
-  .option('-c, --config <path>', 'path to config file');
+  .option('-c, --config <path>', 'path to config file')
+  .option('--no-emoji', 'disable emoji in output');
 
 program
   .command('watch')
@@ -54,8 +55,10 @@ program
   .command('replay <index>')
   .description('Replay queued paste files')
   .action(runReplayCommand);
-maybeShowWelcome();
 program.parse(process.argv);
+const opts = program.opts();
+setUseEmoji(!(opts.noEmoji === true));
+maybeShowWelcome();
 
 function maybeShowWelcome(): void {
   const dir = path.join(process.cwd(), '.uado');

--- a/cli/ui.ts
+++ b/cli/ui.ts
@@ -16,18 +16,46 @@ try {
   };
 }
 
+let emojiEnabled = process.platform !== 'win32' && process.env.NO_EMOJI !== '1';
+
+export function setUseEmoji(flag: boolean): void {
+  emojiEnabled = flag;
+}
+
+function icon(emoji: string, ascii: string): string {
+  return emojiEnabled ? emoji : ascii;
+}
+
+function replaceIcons(line: string): string {
+  if (emojiEnabled) return line;
+  return line
+    .replace(/✅/g, '[ok]')
+    .replace(/❌/g, '[err]')
+    .replace(/💡/g, '[tip]')
+    .replace(/📂/g, '[dir]')
+    .replace(/🧠/g, '[info]')
+    .replace(/📜/g, '[log]')
+    .replace(/📝/g, '[write]')
+    .replace(/🕒/g, '[wait]')
+    .replace(/🔁/g, '[replay]')
+    .replace(/🧾/g, '[#]')
+    .replace(/🎉/g, '*')
+    .replace(/🔴/g, '[!]')
+    .replace(/🟢/g, '[+]');
+}
+
 export function printSuccess(msg: string): void {
-  console.log(chalk.green(`✅ ${msg}`));
+  console.log(chalk.green(replaceIcons(`${icon('✅', 'ok')} ${msg}`)));
 }
 
 export function printError(msg: string): void {
-  console.error(chalk.red(`❌ ${msg}`));
+  console.error(chalk.red(replaceIcons(`${icon('❌', 'err')} ${msg}`)));
 }
 
 export function printTip(msg: string): void {
-  console.log(chalk.cyan(`💡 ${msg}`));
+  console.log(chalk.cyan(replaceIcons(`${icon('💡', 'tip')} ${msg}`)));
 }
 
 export function printInfo(msg: string): void {
-  console.log(chalk.gray(msg));
+  console.log(chalk.gray(replaceIcons(msg)));
 }

--- a/detailed_instructions.md
+++ b/detailed_instructions.md
@@ -1,0 +1,15 @@
+# Detailed Instructions
+
+This document describes how the UADO CLI integrates with your development workflow. It outlines the cooldown engine, queue logging format, and tips for customizing prompts.  
+For a quick overview see the README.
+
+## Cooldown and Prompt Flow
+UADO monitors file changes and editor diagnostics to decide when a prompt can safely run without causing recursive fix loops. The `cooldown-engine` module emits events that the orchestrator listens to before executing prompts.
+
+## Logging Format
+Paste operations are written to `.uado/paste.log.json` and batched queue entries are stored in `.uado/queue.log.json`. Each log record includes timestamps, file paths, and a content hash for later replay.
+
+## Tips
+- Use `uado prompt --simulate-queue` to quickly generate log entries.
+- Run `uado test run` to execute the included CLI regression tests.
+

--- a/test/__snapshots__/paste.log.json
+++ b/test/__snapshots__/paste.log.json
@@ -5,7 +5,8 @@
     "bytesWritten": 10,
     "prompt": "Mock prompt",
     "queueIndex": 1,
-    "wasOverwrite": false
+    "wasOverwrite": false,
+    "hash": "8f47936929a1664e1535397b73820654e7f288f6ab9b667ad1b5bf724fea9306"
   },
   {
     "timestamp": "2024-01-01T00:00:00.000Z",
@@ -13,7 +14,8 @@
     "bytesWritten": 10,
     "prompt": "Mock prompt",
     "queueIndex": 1,
-    "wasOverwrite": false
+    "wasOverwrite": false,
+    "hash": "652783340d5457bb79a8b1b4e06431c7e796c17339451beec3aaaa11a268db48"
   },
   {
     "timestamp": "2024-01-01T00:00:00.000Z",
@@ -21,6 +23,7 @@
     "bytesWritten": 10,
     "prompt": "Mock prompt",
     "queueIndex": 1,
-    "wasOverwrite": false
+    "wasOverwrite": false,
+    "hash": "700ff5a866d55c2576557e1a7253226940ef75bf05f97e821bfa4c1f4c140d34"
   }
 ]

--- a/test/__snapshots__/queue.log.json
+++ b/test/__snapshots__/queue.log.json
@@ -10,7 +10,8 @@
         "bytesWritten": 10,
         "prompt": "Mock prompt",
         "queueIndex": 1,
-        "wasOverwrite": false
+        "wasOverwrite": false,
+        "hash": "8f47936929a1664e1535397b73820654e7f288f6ab9b667ad1b5bf724fea9306"
       },
       {
         "timestamp": "2024-01-01T00:00:00.000Z",
@@ -18,7 +19,8 @@
         "bytesWritten": 10,
         "prompt": "Mock prompt",
         "queueIndex": 1,
-        "wasOverwrite": false
+        "wasOverwrite": false,
+        "hash": "652783340d5457bb79a8b1b4e06431c7e796c17339451beec3aaaa11a268db48"
       },
       {
         "timestamp": "2024-01-01T00:00:00.000Z",
@@ -26,8 +28,10 @@
         "bytesWritten": 10,
         "prompt": "Mock prompt",
         "queueIndex": 1,
-        "wasOverwrite": false
+        "wasOverwrite": false,
+        "hash": "700ff5a866d55c2576557e1a7253226940ef75bf05f97e821bfa4c1f4c140d34"
       }
-    ]
+    ],
+    "hash": "f6cea0c20b7904e6e16dadba591e0870a09e6eed307ce6ba6f923f545141b9f6"
   }
 ]


### PR DESCRIPTION
## Summary
- expand README with full feature list, usage examples and project structure
- add detailed instructions doc
- allow disabling emojis with `--no-emoji`
- make emoji output fallback to ASCII when disabled
- update test snapshots

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e8ab17360832c8cbd2b5a1a35f7b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global CLI option to disable emoji icons in command-line output.
  * CLI output now automatically falls back to ASCII icons on Windows or when emojis are disabled.

* **Documentation**
  * Extensively revised and reorganized the README for improved clarity, added a detailed "Features" section, expanded CLI usage examples, and included configuration and project structure information.
  * Added a new "detailed_instructions.md" document covering advanced CLI integration, logging format, and usage tips.

* **Tests**
  * Updated test snapshots to include cryptographic hash fields in log entries for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->