### PR TITLE
Enable automatic pattern logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - `--simulate-queue` option for prompt testing
 - Styled CLI output with optional emoji icons
 - Pattern-aware prompt injection from `.uado/patterns.json`
+- Automatic pattern logging when prompts succeed
 
 ## Installation
 ```bash
@@ -21,6 +22,8 @@ npm install -g uado
 ```bash
 # Send a prompt
 uado prompt "your prompt"
+# Tag the example for future suggestions
+uado prompt --tag react-component "your prompt"
 
 # Generate fake log entries
 uado prompt --simulate-queue "test"
@@ -58,7 +61,7 @@ Create a `.uadorc.json` in your project root to tweak cooldown behavior and set 
 - `writeCooldownMs` – how long to wait when `cooldownAfterWrite` is enabled (default 60000)
 - `logLevel` – `info`, `debug`, or `silent`
 - `mode` – `manual` for copy/paste mode (used by default if no config file is found)
-- `enablePatternInjection` – set to `true` to inject examples from `.uado/patterns.json`
+- `enablePatternInjection` – set to `true` to inject examples from `.uado/patterns.json` and automatically log successful prompts
 
 ## Pattern-Aware Prompt Injection
 Store successful examples in `.uado/patterns.json`:
@@ -70,6 +73,8 @@ Store successful examples in `.uado/patterns.json`:
 Enable the feature in `.uadorc.json` by setting `"enablePatternInjection": true`.
 When enabled, `uado prompt` will prepend the most similar examples to your prompt.
 Use `uado patterns suggest "your prompt"` to view the top matches without generating code.
+
+When pattern injection is enabled, every successful manual paste automatically adds an entry to `.uado/patterns.json`. Use `--tag <label>` with `uado prompt` to categorize the pattern. Over time this file will grow with examples grouped by tag, improving future suggestions.
 
 ## Project Structure
 ```

--- a/cli/logPattern.ts
+++ b/cli/logPattern.ts
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+export interface PatternEntry {
+  prompt: string;
+  file: string;
+  outputSnippet: string;
+  tag: string;
+  hash: string;
+}
+
+interface PatternsFile {
+  [tag: string]: PatternEntry[];
+}
+
+function hashPrompt(prompt: string): string {
+  return crypto.createHash('sha256').update(prompt).digest('hex');
+}
+
+export function logPattern(
+  prompt: string,
+  file: string,
+  outputSnippet: string,
+  tag = 'general'
+): void {
+  const dir = path.join(process.cwd(), '.uado');
+  const patternsPath = path.join(dir, 'patterns.json');
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // ignore
+  }
+
+  let data: PatternsFile = {};
+  try {
+    if (fs.existsSync(patternsPath)) {
+      const raw = fs.readFileSync(patternsPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        data = { general: parsed as PatternEntry[] };
+      } else if (parsed && typeof parsed === 'object') {
+        data = parsed as PatternsFile;
+      }
+    }
+  } catch {
+    data = {};
+  }
+
+  const hash = hashPrompt(prompt);
+
+  const entries = Object.values(data).flat();
+  if (entries.some((e) => e.hash === hash)) return;
+
+  const entry: PatternEntry = { prompt, file, outputSnippet, tag, hash };
+  if (!Array.isArray(data[tag])) data[tag] = [];
+  data[tag].push(entry);
+
+  try {
+    fs.writeFileSync(patternsPath, JSON.stringify(data, null, 2));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- log successful prompts into `.uado/patterns.json`
- add optional `--tag` for prompt command
- improve pattern matching with cosine similarity
- extend pattern suggestion command for new structure
- update docs with pattern logging workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68604b4c2978832cbb19958d658206dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic logging of successful prompt examples when pattern injection is enabled, with support for tagging and grouping patterns.
  * Introduced a new CLI option to tag prompts for better organization of logged patterns.

* **Improvements**
  * Enhanced pattern suggestion logic to support multiple data formats and display tags with matched patterns.
  * Improved similarity matching for prompt patterns using a more accurate algorithm.

* **Documentation**
  * Updated README to document new pattern logging, tagging, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->