### PR TITLE
Implement UX+validation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,16 @@ npm install -g uado
 
 ## CLI Usage
 ```bash
-# Send a prompt
-uado prompt "your prompt"
-# Tag the example for future suggestions
-uado prompt --tag react-component "your prompt"
+# Quick workflow
+uado guide utility            # learn the basics
+uado prompt --tag demo "Make a button"
+# review snapshot under .uado/snapshots/
+uado replay 1                 # restore the first queue entry
 
-# Generate fake log entries
+# Other commands
 uado prompt --simulate-queue "test"
-
-# View live system dashboard
 uado dashboard
-
-# Show paste history
 uado history
-
-# Start an interactive guide
-uado guide utility
-# Supported scenarios: `utility`, `debug`, `refactor`
-
-# Replay a queue entry
-uado replay <index>
-
-# Run regression tests
 uado test run
 ```
 
@@ -106,6 +94,11 @@ UADO warns about common project pitfalls before writing generated code:
 - Warns when Git has untracked or unstaged files.
 
 Pass `--no-guardrails` to bypass these checks if needed.
+
+## Power User Tips
+- Use `--dry-run` with `prompt` or `replay` to preview file writes without touching disk.
+- Guardrails can be disabled with `--no-guardrails` when you know it's safe.
+- Generated snapshots live under `.uado/snapshots/` and include the prompt hash in their name.
 
 ## Project Structure
 ```

--- a/cli/guide.ts
+++ b/cli/guide.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 import { spawnSync } from 'child_process';
-import { printInfo, printSuccess, printError } from './ui';
+import { printInfo, printSuccess, printError, printTip } from './ui';
 import { PatternEntry } from '../utils/matchPatterns';
 import { logPattern } from './logPattern';
 
@@ -50,6 +50,7 @@ export function registerGuideCommand(program: Command): void {
     .action(async function (scenario: string) {
       if (!SCENARIOS.includes(scenario)) {
         printError('Unknown scenario. Supported: utility, debug, refactor');
+        printTip('Run `uado guide utility` to try the basic flow.');
         return;
       }
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -59,9 +59,10 @@ program
 program
   .command('replay <index>')
   .description('Replay queued paste files')
+  .option('--dry-run', 'Simulate restoring files without writing')
   .action(async function (index: string) {
-    const { config: configPath, noGuardrails } = this.optsWithGlobals();
-    await runReplayCommand(index, configPath, noGuardrails);
+    const { config: configPath, noGuardrails, dryRun } = this.optsWithGlobals();
+    await runReplayCommand(index, configPath, noGuardrails, dryRun);
   });
 program.parse(process.argv);
 const opts = program.opts();

--- a/cli/logPattern.ts
+++ b/cli/logPattern.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import { printWarn } from './ui';
 
 export interface PatternEntry {
   prompt: string;
@@ -51,7 +52,18 @@ export function logPattern(
   const hash = hashPrompt(prompt);
 
   const entries = Object.values(data).flat();
-  if (entries.some((e) => e.hash === hash)) return;
+  if (!outputSnippet.trim()) {
+    printWarn('Pattern logging skipped: output snippet is empty.');
+    return;
+  }
+  if (!tag.trim()) {
+    printWarn('Pattern logging skipped: tag is required.');
+    return;
+  }
+  if (entries.some((e) => e.hash === hash)) {
+    printWarn('Pattern already exists. Skipping duplicate.');
+    return;
+  }
 
   const entry: PatternEntry = { prompt, file, outputSnippet, tag, hash };
   if (!Array.isArray(data[tag])) data[tag] = [];

--- a/cli/patterns.ts
+++ b/cli/patterns.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
-import { printError, printInfo } from './ui';
+import { printError, printInfo, printTip } from './ui';
 import { findBestMatches, PatternEntry } from '../utils/matchPatterns';
 import { explainPattern } from '../utils/explainPattern';
 
@@ -18,6 +18,7 @@ export function registerPatternsCommand(program: Command): void {
         raw = JSON.parse(fs.readFileSync(patternsPath, 'utf8'));
       } catch (err: any) {
         printError(`Failed to read patterns: ${err.message}`);
+        printTip('Try generating patterns using `uado guide` or `uado prompt --tag` first.');
         return;
       }
 
@@ -30,6 +31,7 @@ export function registerPatternsCommand(program: Command): void {
         }
       } else {
         printError('patterns.json is not in the expected format.');
+        printTip('You can delete it and re-run `uado guide` to regenerate.');
         return;
       }
 
@@ -58,6 +60,7 @@ export function registerPatternsCommand(program: Command): void {
         raw = JSON.parse(fs.readFileSync(patternsPath, 'utf8'));
       } catch (err: any) {
         printError(`Failed to read patterns: ${err.message}`);
+        printTip('Run `uado guide` to create your first pattern examples.');
         return;
       }
 
@@ -70,12 +73,14 @@ export function registerPatternsCommand(program: Command): void {
         }
       } else {
         printError('patterns.json is not in the expected format.');
+        printTip('Delete the file and re-run `uado guide` to start fresh.');
         return;
       }
 
       const filtered = all.filter((p) => p.tag === tag);
       if (filtered.length === 0) {
         printInfo(`No patterns found for tag "${tag}".`);
+        printTip(`Add one using \`uado prompt --tag ${tag} <text>\``);
         return;
       }
 

--- a/cli/snapshot.ts
+++ b/cli/snapshot.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+export function saveSnapshot(content: string, hash: string): string {
+  const dir = path.join(process.cwd(), '.uado', 'snapshots');
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const file = path.join(dir, `${timestamp}-${hash}.txt`);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(file, content);
+  return path.relative(process.cwd(), file);
+}


### PR DESCRIPTION
## Summary
- add snapshot logger utility
- support `--dry-run` in `prompt` and `replay`
- warn on invalid pattern entries when logging
- improve help messages in guide and pattern commands
- show confirmation with elapsed time after prompts
- document power user tips and workflow examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860575abf5c832c801c14931842d366