### PR TITLE
Add status/version/config commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ uado prompt --simulate-queue "test"
 uado dashboard
 uado history
 uado test run
+uado status
+uado config
+uado version
 ```
 
-Add `--no-emoji` to disable icons if your terminal does not display them correctly.
+Add `--no-emoji` to disable icons if your terminal does not display them correctly. `--dry-run` and `--no-emoji` are internal flags for debugging and may change without notice.
 
 ## Configuration
 Create a `.uadorc.json` in your project root to tweak cooldown behavior and set execution mode:
@@ -96,7 +99,7 @@ UADO warns about common project pitfalls before writing generated code:
 Pass `--no-guardrails` to bypass these checks if needed.
 
 ## Power User Tips
-- Use `--dry-run` with `prompt` or `replay` to preview file writes without touching disk.
+- Use `--dry-run` with `prompt` or `replay` to preview file writes without touching disk (internal flag).
 - Guardrails can be disabled with `--no-guardrails` when you know it's safe.
 - Generated snapshots live under `.uado/snapshots/` and include the prompt hash in their name.
 

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander';
+import { loadConfig, UadoConfig } from '../core/config-loader';
+import { printInfo } from './ui';
+
+const EXPLAIN: Record<keyof UadoConfig, string> = {
+  cooldownDurationMs: 'maximum time to stay in cooldown after a file change',
+  stabilityWindowMs: 'how long to wait after LSP reports ready',
+  logLevel: 'info, debug, or silent',
+  mode: 'openai, claude, or manual copy/paste mode',
+  cooldownAfterWrite: 'enable a delay after writing files',
+  writeCooldownMs: 'cooldown duration when cooldownAfterWrite is enabled',
+  enablePatternInjection: 'inject examples from .uado/patterns.json'
+};
+
+export function registerConfigCommand(program: Command): void {
+  program
+    .command('config')
+    .description('Show resolved configuration with explanations')
+    .action(function () {
+      const { config: configPath } = this.optsWithGlobals();
+      const cfg = loadConfig(configPath);
+      printInfo('');
+      for (const [k, v] of Object.entries(cfg)) {
+        const key = k as keyof UadoConfig;
+        const explain = EXPLAIN[key];
+        printInfo(`${key}: ${JSON.stringify(v)}${explain ? ' // ' + explain : ''}`);
+      }
+    });
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -12,6 +12,9 @@ import { registerGuideCommand } from './guide';
 import { runHistoryCommand } from './history';
 import { registerTestCommand } from './test';
 import { runReplayCommand } from './replay';
+import { registerStatusCommand } from './status';
+import { registerVersionCommand } from './version';
+import { registerConfigCommand } from './config';
 
 import { printInfo, setUseEmoji } from './ui';
 
@@ -52,6 +55,9 @@ registerPromptCommand(program);
 registerPatternsCommand(program);
 registerGuideCommand(program);
 registerTestCommand(program);
+registerStatusCommand(program);
+registerVersionCommand(program);
+registerConfigCommand(program);
 program
   .command('history')
   .description('Show paste history')

--- a/cli/status.ts
+++ b/cli/status.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { loadConfig } from '../core/config-loader';
+import { printInfo } from './ui';
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command('status')
+    .description('Show current configuration and log status')
+    .action(function () {
+      const { config: configPath, noGuardrails } = this.optsWithGlobals();
+      const cfg = loadConfig(configPath);
+
+      printInfo('\nConfiguration:');
+      const entries: Array<[string, unknown]> = Object.entries(cfg);
+      for (const [k, v] of entries) {
+        printInfo(`- ${k}: ${JSON.stringify(v)}`);
+      }
+      printInfo(`- guardrails: ${noGuardrails ? 'disabled' : 'enabled'}`);
+
+      const queuePath = path.join(process.cwd(), '.uado', 'queue.log.json');
+      let queueSize = 0;
+      try {
+        const raw = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+        if (Array.isArray(raw)) queueSize = raw.length;
+      } catch {
+        queueSize = 0;
+      }
+      printInfo(`\nQueue entries: ${queueSize}`);
+
+      printInfo('\nActive logs:');
+      const files = ['paste.log.json', 'queue.log.json', 'patterns.json'];
+      const dir = path.join(process.cwd(), '.uado');
+      for (const f of files) {
+        const exists = fs.existsSync(path.join(dir, f));
+        if (exists) printInfo(`- ${f}`);
+      }
+    });
+}

--- a/cli/version.ts
+++ b/cli/version.ts
@@ -1,0 +1,16 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { printInfo } from './ui';
+
+export function registerVersionCommand(program: Command): void {
+  program
+    .command('version')
+    .description('Print CLI version')
+    .action(() => {
+      const pkgPath = path.join(__dirname, '..', 'package.json');
+      const raw = fs.readFileSync(pkgPath, 'utf8');
+      const pkg = JSON.parse(raw) as { version?: string };
+      printInfo(pkg.version || 'unknown');
+    });
+}


### PR DESCRIPTION
## Summary
- add new CLI helpers (`status`, `version`, `config`)
- register commands in the main program
- document new commands and internal flags in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686059e9f964832c9bdf38ed552a3d8b