### PR TITLE
Add pre-write lint checks and cooldown logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Features
 - Prompt handling with cooldown prediction
 - Paste and queue logging to `.uado/`
+- Lint and TypeScript review logs in `.uado/review.log.json`
 - `history` command for browsing past prompts
 - `replay` command for restoring queued files
 - Built‑in test framework
@@ -55,7 +56,7 @@ Create a `.uadorc.json` in your project root to tweak cooldown behavior and set 
 - `cooldownDurationMs` – maximum time to stay in cooldown after a file change
 - `stabilityWindowMs` – how long to wait for file stability after the LSP signals readiness
 - `cooldownAfterWrite` – enable a delay after writing files
-- `writeCooldownMs` – how long to wait when `cooldownAfterWrite` is enabled (default 60000)
+- `writeCooldownMs` – how long to wait when `cooldownAfterWrite` is enabled (default 60000). After each write UADO displays a cooldown banner so lint and TypeScript can stabilize.
 - `logLevel` – `info`, `debug`, or `silent`
 - `mode` – `manual` for copy/paste mode (used by default if no config file is found)
 - `enablePatternInjection` – set to `true` to inject examples from `.uado/patterns.json` and automatically log successful prompts

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -66,9 +66,10 @@ program
   .command('replay <index>')
   .description('Replay queued paste files')
   .option('--dry-run', 'Simulate restoring files without writing')
+  .option('--force', 'Write even if linting fails')
   .action(async function (index: string) {
-    const { config: configPath, noGuardrails, dryRun } = this.optsWithGlobals();
-    await runReplayCommand(index, configPath, noGuardrails, dryRun);
+    const { config: configPath, noGuardrails, dryRun, force } = this.optsWithGlobals();
+    await runReplayCommand(index, configPath, noGuardrails, dryRun, force);
   });
 program.parse(process.argv);
 const opts = program.opts();

--- a/cli/logReview.ts
+++ b/cli/logReview.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ReviewLogEntry {
+  file: string;
+  result: 'passed' | 'failed';
+  eslintErrors: string[];
+  tscErrors: string[];
+  timestamp: string;
+}
+
+export function logReview(entry: ReviewLogEntry): void {
+  const dir = path.join(process.cwd(), '.uado');
+  const logPath = path.join(dir, 'review.log.json');
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // ignore
+  }
+
+  let log: ReviewLogEntry[] = [];
+  try {
+    if (fs.existsSync(logPath)) {
+      const raw = fs.readFileSync(logPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) log = parsed as ReviewLogEntry[];
+    } else {
+      fs.writeFileSync(logPath, '[]', { flag: 'wx' });
+    }
+  } catch {
+    log = [];
+  }
+
+  log.push(entry);
+  try {
+    fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
+  } catch {
+    // ignore
+  }
+}
+

--- a/cli/validate.ts
+++ b/cli/validate.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+export interface LintResult {
+  passed: boolean;
+  eslintErrors: string[];
+  tscErrors: string[];
+}
+
+function run(cmd: string, args: string[]): { status: number | null; stdout: string; stderr: string } {
+  return spawnSync(cmd, args, { encoding: 'utf8' });
+}
+
+export function validateCode(content: string, dest: string): LintResult {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uado-validate-'));
+  const tmpFile = path.join(tmpDir, path.basename(dest));
+  fs.writeFileSync(tmpFile, content);
+
+  let eslintErrors: string[] = [];
+  let tscErrors: string[] = [];
+
+  const eslintCmd = path.join(process.cwd(), 'node_modules', '.bin', 'eslint');
+  if (fs.existsSync(eslintCmd)) {
+    const res = run(eslintCmd, ['--quiet', tmpFile]);
+    if (res.status !== 0) {
+      const out = (res.stdout + res.stderr).trim();
+      if (out) eslintErrors = out.split(/\n/).filter(Boolean);
+    }
+  }
+
+  const tscCmd = path.join(process.cwd(), 'node_modules', '.bin', 'tsc');
+  if (fs.existsSync(tscCmd)) {
+    const res = run(tscCmd, ['--noEmit', tmpFile]);
+    if (res.status !== 0) {
+      const out = (res.stdout + res.stderr).trim();
+      if (out) tscErrors = out.split(/\n/).filter(Boolean);
+    }
+  }
+
+  const passed = eslintErrors.length === 0 && tscErrors.length === 0;
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return { passed, eslintErrors, tscErrors };
+}
+


### PR DESCRIPTION
## Summary
- run eslint and tsc before writing files
- log review results for each attempted write
- respect cooldownAfterWrite with new banner
- add `--force` option for `prompt` and `replay`
- document review logs and cooldown behavior

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686060d3ffc8832c95693f616e878247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to the CLI commands to allow saving files even if linting or type validation fails.
  * Introduced automatic logging of lint and TypeScript review results to a persistent log file for improved tracking.
  * Added on-demand code validation using ESLint and TypeScript before saving files.

* **Documentation**
  * Updated the README to reflect the new logging feature and clarified the cooldown banner behavior after file writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->