### PR TITLE
Add starred prompt workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - Styled CLI output with optional emoji icons
 - Pattern-aware prompt injection from `.uado/patterns.json`
 - Automatic pattern logging when prompts succeed
+- `star` command to bookmark past prompts
+- `starred` list with `suggest` and `diff`
 - Interactive `guide` command for beginner workflows
 - Beginner guardrails for common project pitfalls
 - Progressive difficulty levels with `uado level` and `--difficulty`
@@ -29,6 +31,10 @@ uado guide utility            # learn the basics
 uado prompt --tag demo "Make a button"
 # review snapshot under .uado/snapshots/
 uado replay 1                 # restore the first queue entry
+uado star 1                   # bookmark entry #1
+uado starred                  # list saved examples
+uado suggest "new prompt"     # show similar stars
+uado diff 1                   # diff latest with star #1
 
 # Other commands
 uado prompt --simulate-queue "test"
@@ -111,6 +117,7 @@ Pass `--no-guardrails` to bypass these checks if needed.
 - Use `--dry-run` with `prompt` or `replay` to preview file writes without touching disk (internal flag).
 - Guardrails can be disabled with `--no-guardrails` when you know it's safe.
 - Generated snapshots live under `.uado/snapshots/` and include the prompt hash in their name.
+- Starred examples are stored in `.uado/starred.json` and follow `prompt.schema.json`.
 
 ## Project Structure
 ```

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@ import { loadConfig } from '../core/config-loader';
 import { registerDashboardCommand } from './dashboard';
 import { registerPromptCommand } from './prompt';
 import { registerPatternsCommand } from './patterns';
+import { registerStarCommand } from './star';
 import { registerGuideCommand } from './guide';
 import { runHistoryCommand } from './history';
 import { registerTestCommand } from './test';
@@ -60,6 +61,7 @@ registerStatusCommand(program);
 registerVersionCommand(program);
 registerConfigCommand(program);
 registerLevelCommand(program);
+registerStarCommand(program);
 program
   .command('history')
   .description('Show paste history')

--- a/cli/star.ts
+++ b/cli/star.ts
@@ -1,0 +1,204 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { PasteLogEntry } from './logPaste';
+import { printError, printInfo, printSuccess } from './ui';
+import { computeHash } from '../utils/hash';
+import { cosineSimilarity } from '../utils/matchPatterns';
+
+export interface StarredEntry {
+  prompt: string;
+  output: string;
+  file: string;
+  timestamp: string;
+  hash: string;
+  tag?: string;
+}
+
+export function registerStarCommand(program: Command): void {
+  program
+    .command('star <index>')
+    .description('Star a prompt from history')
+    .option('--tag <tag>', 'optional tag')
+    .action(function (indexStr: string) {
+      const { tag } = this.optsWithGlobals();
+      const logPath = path.join(process.cwd(), '.uado', 'paste.log.json');
+      if (!fs.existsSync(logPath)) {
+        printError('No paste log found');
+        return;
+      }
+      let data: unknown;
+      try {
+        data = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      } catch (err: any) {
+        printError(`Failed to read paste log: ${err.message}`);
+        return;
+      }
+      if (!Array.isArray(data)) {
+        printError('paste.log.json is not in expected format');
+        return;
+      }
+      const entries = (data as PasteLogEntry[]).slice().sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      const index = parseInt(indexStr, 10);
+      if (Number.isNaN(index) || index < 1 || index > entries.length) {
+        printError('Invalid index');
+        return;
+      }
+      const entry = entries[index - 1];
+      const hash = entry.hash || computeHash(entry);
+      const snapDir = path.join(process.cwd(), '.uado', 'snapshots');
+      const snap = fs
+        .readdirSync(snapDir, { withFileTypes: true })
+        .filter((d) => d.isFile() && d.name.includes(hash))[0];
+      if (!snap) {
+        printError('Snapshot for entry not found');
+        return;
+      }
+      const output = fs.readFileSync(path.join(snapDir, snap.name), 'utf8');
+      const starPath = path.join(process.cwd(), '.uado', 'starred.json');
+      let stars: StarredEntry[] = [];
+      try {
+        if (fs.existsSync(starPath)) {
+          const raw = fs.readFileSync(starPath, 'utf8');
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) stars = parsed as StarredEntry[];
+        } else {
+          fs.mkdirSync(path.dirname(starPath), { recursive: true });
+          fs.writeFileSync(starPath, '[]');
+        }
+      } catch {
+        stars = [];
+      }
+      const starEntry: StarredEntry = {
+        prompt: entry.prompt,
+        output,
+        file: entry.file,
+        timestamp: entry.timestamp,
+        hash,
+        tag
+      };
+      stars.push(starEntry);
+      try {
+        fs.writeFileSync(starPath, JSON.stringify(stars, null, 2));
+        printSuccess('Prompt starred');
+      } catch (err: any) {
+        printError(`Failed to update starred.json: ${err.message}`);
+      }
+    });
+
+  program
+    .command('starred')
+    .description('List starred prompts')
+    .option('--limit <n>', 'limit results')
+    .action(function () {
+      const { limit } = this.optsWithGlobals();
+      const starPath = path.join(process.cwd(), '.uado', 'starred.json');
+      if (!fs.existsSync(starPath)) {
+        printInfo('No starred prompts found');
+        return;
+      }
+      let data: unknown;
+      try {
+        data = JSON.parse(fs.readFileSync(starPath, 'utf8'));
+      } catch (err: any) {
+        printError(`Failed to read starred prompts: ${err.message}`);
+        return;
+      }
+      if (!Array.isArray(data)) {
+        printError('starred.json is not in expected format');
+        return;
+      }
+      const entries = data as StarredEntry[];
+      const max = limit ? parseInt(limit, 10) : entries.length;
+      for (const e of entries.slice(0, max)) {
+        const preview = e.prompt.replace(/\s+/g, ' ').slice(0, 60);
+        const count = e.output.split(/\r?\n/).length;
+        printInfo(`⭐ [${e.tag || 'general'}] ${e.timestamp} (${count} lines)`);
+        printInfo(`  ${preview}`);
+        printInfo('');
+      }
+    });
+
+  program
+    .command('suggest <text>')
+    .description('Suggest similar starred prompts')
+    .option('--limit <n>', 'limit results')
+    .action(function (text: string) {
+      const { limit } = this.optsWithGlobals();
+      const starPath = path.join(process.cwd(), '.uado', 'starred.json');
+      if (!fs.existsSync(starPath)) {
+        printInfo('No starred prompts found');
+        return;
+      }
+      let data: unknown;
+      try {
+        data = JSON.parse(fs.readFileSync(starPath, 'utf8'));
+      } catch (err: any) {
+        printError(`Failed to read starred prompts: ${err.message}`);
+        return;
+      }
+      if (!Array.isArray(data)) {
+        printError('starred.json is not in expected format');
+        return;
+      }
+      const entries = data as StarredEntry[];
+      const scored = entries
+        .map((e) => ({ score: cosineSimilarity(text, e.prompt), entry: e }))
+        .filter((s) => s.score > 0)
+        .sort((a, b) => b.score - a.score);
+      const max = limit ? parseInt(limit, 10) : 3;
+      for (const s of scored.slice(0, max)) {
+        printInfo(`⭐ [${s.entry.tag || 'general'}] ${(s.score * 100).toFixed(0)}%`);
+        printInfo(`  ${s.entry.prompt}`);
+        printInfo('');
+      }
+    });
+
+  program
+    .command('diff <index>')
+    .description('Diff latest snapshot with a starred prompt')
+    .action(function (indexStr: string) {
+      const starPath = path.join(process.cwd(), '.uado', 'starred.json');
+      if (!fs.existsSync(starPath)) {
+        printError('No starred prompts found');
+        return;
+      }
+      let data: unknown;
+      try {
+        data = JSON.parse(fs.readFileSync(starPath, 'utf8'));
+      } catch (err: any) {
+        printError(`Failed to read starred prompts: ${err.message}`);
+        return;
+      }
+      if (!Array.isArray(data)) {
+        printError('starred.json is not in expected format');
+        return;
+      }
+      const entries = data as StarredEntry[];
+      const index = parseInt(indexStr, 10);
+      if (Number.isNaN(index) || index < 1 || index > entries.length) {
+        printError('Invalid index');
+        return;
+      }
+      const entry = entries[index - 1];
+      const snapDir = path.join(process.cwd(), '.uado', 'snapshots');
+      const snaps = fs
+        .readdirSync(snapDir, { withFileTypes: true })
+        .filter((d) => d.isFile())
+        .sort((a, b) => b.name.localeCompare(a.name));
+      if (snaps.length === 0) {
+        printError('No snapshots found');
+        return;
+      }
+      const latest = fs.readFileSync(path.join(snapDir, snaps[0].name), 'utf8');
+      let diffOutput = '';
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { diffStringsUnified } = require('@vitest/utils/diff');
+        diffOutput = diffStringsUnified(entry.output, latest);
+      } catch {
+        diffOutput = 'diff library unavailable';
+      }
+      console.log(diffOutput);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^24.0.4",
     "memfs": "^4.17.2",
     "mock-fs": "^5.5.0",
-    "vitest": "^3.2.4",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/prompt.schema.json
+++ b/prompt.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UADO Prompt Entry",
+  "type": "object",
+  "properties": {
+    "prompt": { "type": "string" },
+    "output": { "type": "string" },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "difficulty": { "type": "string" },
+    "hash": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "file": { "type": "string" }
+  },
+  "required": ["prompt", "output", "hash", "timestamp"]
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -137,6 +137,22 @@ function testGitChanges(): TestResult {
   return { name: 'guardrail-git-status', passed, message: passed ? undefined : 'warning missing' };
 }
 
+function testStarCommand(): TestResult {
+  const dir = makeTmpDir();
+  runCmd(['test', 'mock-paste'], dir);
+  const pastePath = path.join(dir, '.uado', 'paste.log.json');
+  const entries = readJSON(pastePath);
+  const hash = entries[0].hash;
+  const snapDir = path.join(dir, '.uado', 'snapshots');
+  fs.mkdirSync(snapDir, { recursive: true });
+  fs.writeFileSync(path.join(snapDir, `snap-${hash}.txt`), 'output');
+  runCmd(['star', '1'], dir);
+  const starPath = path.join(dir, '.uado', 'starred.json');
+  const star = readJSON(starPath);
+  const passed = Array.isArray(star) && star.length === 1 && star[0].output === 'output';
+  return { name: 'star-command', passed, message: passed ? undefined : 'missing star' };
+}
+
 function main(): void {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uado-test-'));
   const results = [
@@ -148,7 +164,8 @@ function main(): void {
     testMissingPackageJson(),
     testNodeModules(),
     testMergeConflicts(),
-    testGitChanges()
+    testGitChanges(),
+    testStarCommand()
   ];
 
   for (const r of results) {

--- a/utils/matchPatterns.ts
+++ b/utils/matchPatterns.ts
@@ -11,7 +11,7 @@ function tokenize(text: string): string[] {
   return text.toLowerCase().split(/\W+/).filter(Boolean);
 }
 
-function cosineSimilarity(a: string, b: string): number {
+export function cosineSimilarity(a: string, b: string): number {
   const aTokens = tokenize(a);
   const bTokens = tokenize(b);
   const countsA: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- implement star memory workflow
- show suggestions from `starred.json`
- add CLI commands `star`, `starred`, `suggest`, and `diff`
- export cosine similarity helper
- document features and new schema
- add regression test for `star` command

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860680dd340832c8504a48e10dea36f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced commands to bookmark prompts, list starred prompts, suggest similar prompts, and compare prompts via the CLI.
  * Added support for storing and managing starred prompts in a dedicated file.
  * Implemented similarity suggestions for prompts based on previous entries.

* **Documentation**
  * Updated documentation to describe new CLI commands and features related to bookmarking and managing prompts.

* **Tests**
  * Added tests to verify bookmarking (star) functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->