### PR TITLE
Add Jest test setup

### DIFF
--- a/__tests__/sample.test.ts
+++ b/__tests__/sample.test.ts
@@ -1,0 +1,3 @@
+test('RunSafe test system works', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  transform: {},
+  moduleNameMapper: {},
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "scripts": {
     "build": "tsc --outDir dist --rootDir . && chmod +x dist/index.js",
-    "test": "npm run build && node dist/test/cli.test.js"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "chokidar": "^4.0.3",
     "commander": "^14.0.0",
@@ -23,9 +23,12 @@
   "devDependencies": {
     "@types/chokidar": "^1.7.5",
     "@types/commander": "^2.12.0",
-    "@types/node": "^24.0.4",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^24.0.8",
+    "jest": "^29.7.0",
     "memfs": "^4.17.2",
     "mock-fs": "^5.5.0",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.4.0",
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
## Summary
- add Jest config for ts-jest with ESM
- create sample test under `__tests__/`
- switch to ESM in `package.json` and use jest script
- declare jest-related dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864056e4fb4832caa85f693d4db26b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a basic test to verify the test system is working.
  * Introduced a new testing setup using Jest with TypeScript support.

* **Chores**
  * Updated development dependencies and scripts to use Jest for running tests.
  * Changed the module system to ES modules for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->